### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,6 +5,9 @@ jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Check files using the black formatter


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/Weather/security/code-scanning/2](https://github.com/Alcheri/Weather/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the scopes this job needs, either at the workflow root (applies to all jobs) or inside the specific job. Here, the `linter_name` job needs to check out code (`contents: read`) and create or update pull requests and commits (`contents: write` and `pull-requests: write`). The `rickstaa/action-black` step itself does not need extra token scopes beyond what the job already has.

The best minimal fix without changing functionality is to add a `permissions` block under the `linter_name` job in `.github/workflows/black.yml`. Concretely, insert:

```yaml
    permissions:
      contents: write
      pull-requests: write
```

right under the `runs-on: ubuntu-latest` line for that job. This scopes the `GITHUB_TOKEN` to only the permissions required for checkout and PR creation. No additional imports, methods, or other definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
