### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/Weather/security/code-scanning/1](https://github.com/Alcheri/Weather/security/code-scanning/1)

In general, the fix is to explicitly define `permissions` for the workflow or job so that the `GITHUB_TOKEN` has only the minimal required scopes. Since this workflow just checks out code, prints environment information, and lists files, it only needs read access to repository contents.

The best fix with no functional change is to add a root-level `permissions:` block (so it applies to all jobs) right after the `name:` or `run-name:` fields. We’ll set `contents: read`, which is the minimal permission needed for `actions/checkout` to fetch the repository. No other scopes (like `pull-requests`, `issues`, etc.) are required by the current steps.

Concretely, in `.github/workflows/github-actions-demo.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing header fields and the `on:` trigger. No additional imports, methods, or definitions are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
